### PR TITLE
Feature/rotation support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,18 +23,19 @@ import InteractiveSideMenu
 
 class KittyViewController: UIViewController, SideMenuItemContent {
 
-    @IBAction func didOpenMenu(_ sender: UIButton) {
+    @IBAction func openMenu(_ sender: UIButton) {
         showSideMenu()
     }
 }
 ```
-- To set custom animation options you should now override ```menuTransitionOptions()``` method from ```MenuContainerViewColtroller``` class.
+-  To customize animation you should now call ```setMenuTransition(options:)``` method from ```MenuContainerViewColtroller``` class.
 ```swift
-override func menuTransitionOptions() -> TransitionOptions? {
-    var options = TransitionOptions(duration: 0.4, contentScale: 0.9)
-    options.useFinishingSpringOption = false
-    options.useCancelingSpringOption = false
-    return options
+override func viewDidLoad() {
+    super.viewDidLoad()
+    let screenSize: CGRect = UIScreen.main.bounds
+    let params = TransitionOptions(duration: 0.4, visibleContentWidth: screenSize.width / 6)
+    setMenuTransition(options: params)
+    ...
 }
 ```
 
@@ -42,10 +43,10 @@ override func menuTransitionOptions() -> TransitionOptions? {
 ```swift
 override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
     super.viewWillTransition(to: size, with: coordinator)
-    var options = TransitionOptions()
-    options.duration = size.width < size.height ? 0.4 : 0.6
-    options.visibleContentWidth = size.width / 5
-    updateMenuTransition(options: options)
+    var params = TransitionOptions()
+    params.duration = size.width < size.height ? 0.4 : 0.6
+    params.visibleContentWidth = size.width / 6
+    setMenuTransition(options: params)
 }
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ All notable changes to the library will be documented in this file.
 ### Fixed
 - Displaying horizontal images in [Sample](./Sample)
 
-**Migration note:** to mark UIViewController as item of SideMenu you should adopt `SideMenuItemContent` protocol instead of inheritance.
+**Migration notes**
+
+- To mark UIViewController as item of SideMenu you should adopt `SideMenuItemContent` protocol instead of inheritance.
 To show menu you should call `showSideMenu()` method from this protocol.
 ```swift
 import InteractiveSideMenu
@@ -24,6 +26,15 @@ class KittyViewController: UIViewController, SideMenuItemContent {
     @IBAction func didOpenMenu(_ sender: UIButton) {
         showSideMenu()
     }
+}
+```
+- To set custom animation options you should now override ```menuTransitionOptions()``` method from ```MenuContainerViewColtroller``` class.
+```swift
+override func menuTransitionOptions() -> TransitionOptions? {
+    var options = TransitionOptions(duration: 0.4, contentScale: 0.9)
+    options.useFinishingSpringOption = false
+    options.useCancelingSpringOption = false
+    return options
 }
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,17 @@ override func menuTransitionOptions() -> TransitionOptions? {
 }
 ```
 
+- Now you have possibility to update customization settings using ```viewWillTransition(to:with:)``` mehod.
+```swift
+override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+    super.viewWillTransition(to: size, with: coordinator)
+    var options = TransitionOptions()
+    options.duration = size.width < size.height ? 0.4 : 0.6
+    options.visibleContentWidth = size.width / 5
+    updateMenuTransition(options: options)
+}
+```
+
 ## 1.0 - 2017-01-23
 ### Added
 - LeftSideMenu with possibility to customize menu animation and content    

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,13 +28,12 @@ class KittyViewController: UIViewController, SideMenuItemContent {
     }
 }
 ```
--  To customize animation you should now call ```setMenuTransition(options:)``` method from ```MenuContainerViewColtroller``` class.
+-  To customize animation you should now update ```transitionOptions``` property in ```MenuContainerViewColtroller``` class.
 ```swift
 override func viewDidLoad() {
     super.viewDidLoad()
     let screenSize: CGRect = UIScreen.main.bounds
-    let params = TransitionOptions(duration: 0.4, visibleContentWidth: screenSize.width / 6)
-    setMenuTransition(options: params)
+    self.transitionOptions = TransitionOptions(duration: 0.4, visibleContentWidth: screenSize.width / 6)
     ...
 }
 ```
@@ -43,10 +42,10 @@ override func viewDidLoad() {
 ```swift
 override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
     super.viewWillTransition(to: size, with: coordinator)
-    var params = TransitionOptions()
-    params.duration = size.width < size.height ? 0.4 : 0.6
-    params.visibleContentWidth = size.width / 6
-    setMenuTransition(options: params)
+    var options = TransitionOptions()
+    options.duration = size.width < size.height ? 0.4 : 0.6
+    options.visibleContentWidth = size.width / 6
+    self.transitionOptions = options
 }
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the library will be documented in this file.
 ## [Unreleased]
 ### Added
 - UITabBarController and UINavigationController menu items support
-- Rotation support (plan)
+- Rotation support
 - Right SideMenu support (plan)
 - CHANGELOG file
 

--- a/README.md
+++ b/README.md
@@ -78,22 +78,22 @@ class KittyViewController: UIViewController, SideMenuItemContent {
 
 To change content view you should choose desired content controller and hide menu.
 ```swift
-let index = 2 // second menu item
-guard let menuContainerViewController = self.menuContainerViewController else { return }
-let contentController = menuContainerViewController.contentViewControllers[index]
-menuContainerViewController.selectContentViewController(contentController)
-menuContainerViewController.hideMenu()
+    let index = 2 // second menu item
+    guard let menuContainerViewController = self.menuContainerViewController else { return }
+    let contentController = menuContainerViewController.contentViewControllers[index]
+    menuContainerViewController.selectContentViewController(contentController)
+    menuContainerViewController.hideMenu()
  ```
 
- To customize animation for menu opening or closing you should override ```menuTransitionOptionsBuilder()``` method that is available in ```MenuContainerViewColtroller``` class.
+To customize animation for menu opening or closing you should override ```menuTransitionOptions()``` method that is available in ```MenuContainerViewColtroller``` class.
  ```swift
- override func menuTransitionOptionsBuilder() -> TransitionOptionsBuilder? {
-    return TransitionOptionsBuilder() { builder in
-        builder.duration = 0.5
-        builder.contentScale = 1
-    }
+override func menuTransitionOptions() -> TransitionOptions? {
+    var options = TransitionOptions(duration: 0.4, contentScale: 0.9)
+    options.useFinishingSpringOption = false
+    options.useCancelingSpringOption = false
+    return options
 }
-  ```
+```
 
  See [Sample](./Sample) for more details.
 

--- a/README.md
+++ b/README.md
@@ -85,29 +85,28 @@ To change content view you should choose desired content controller and hide men
     menuContainerViewController.hideMenu()
  ```
 
-To customize animation for menu opening or closing you should call ```setMenuTransition(options:)``` method that is available in ```MenuContainerViewColtroller``` class. Initial setup could be done, for example, on controller's ```viewDidLoad()```.
+To customize animation for menu opening or closing you should update ```transitionOptions``` property that is available in ```MenuContainerViewColtroller``` class. Initial setup could be done, for example, on controller's ```viewDidLoad()```.
  ```swift
 override func viewDidLoad() {
     super.viewDidLoad()
     let screenSize: CGRect = UIScreen.main.bounds
-    let params = TransitionOptions(duration: 0.4, visibleContentWidth: screenSize.width / 6)
-    setMenuTransition(options: params)
+    self.transitionOptions = TransitionOptions(duration: 0.4, visibleContentWidth: screenSize.width / 6)
     ...
 }
 ```
 
-Also you have possibility to update customization settings, e.g. set another options for landscape orientation. To do it you should override ```viewWillTransition(to:with:)``` mehod and call ```setMenuTransition(options:)``` with desired parameters.
+Also you have possibility to update customization settings, e.g. set another options for landscape orientation. To do it you should override ```viewWillTransition(to:with:)``` mehod and add desired parameters to ```transitionOptions``` property.
 ```swift
 override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
     super.viewWillTransition(to: size, with: coordinator)
-    var params = TransitionOptions()
-    params.duration = size.width < size.height ? 0.4 : 0.6
-    params.visibleContentWidth = size.width / 6
-    setMenuTransition(options: params)
+    var options = TransitionOptions()
+    options.duration = size.width < size.height ? 0.4 : 0.6
+    options.visibleContentWidth = size.width / 6
+    self.transitionOptions = options
 }
 ```
 
-Method ```updateMenuTransition(options:)``` could be called for setting different options for Compact and Regular sizes as well. Method ```traitCollectionDidChange(_: )``` should be used in this case.
+Transition options could be used to set different settings for Compact and Regular sizes as well. To do it you should implement ViewController's ```traitCollectionDidChange(_: )``` callback.
 
  See [Sample](./Sample) for more details.
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ import InteractiveSideMenu
 
 class KittyViewController: UIViewController, SideMenuItemContent {
     
-    @IBAction func didOpenMenu(_ sender: UIButton) {
+    @IBAction func openMenu(_ sender: UIButton) {
         showSideMenu()
     }
 }
@@ -85,24 +85,25 @@ To change content view you should choose desired content controller and hide men
     menuContainerViewController.hideMenu()
  ```
 
-To customize animation for menu opening or closing you should override ```menuTransitionOptions()``` method that is available in ```MenuContainerViewColtroller``` class.
+To customize animation for menu opening or closing you should call ```setMenuTransition(options:)``` method that is available in ```MenuContainerViewColtroller``` class. Initial setup could be done, for example, on controller's ```viewDidLoad()```.
  ```swift
-override func menuTransitionOptions() -> TransitionOptions? {
-    var options = TransitionOptions(duration: 0.4, contentScale: 0.9)
-    options.useFinishingSpringOption = false
-    options.useCancelingSpringOption = false
-    return options
+override func viewDidLoad() {
+    super.viewDidLoad()
+    let screenSize: CGRect = UIScreen.main.bounds
+    let params = TransitionOptions(duration: 0.4, visibleContentWidth: screenSize.width / 6)
+    setMenuTransition(options: params)
+    ...
 }
 ```
 
-Also you have possibility to update customization settings, e.g. set another options for landscape orientation. To do it you should override ```viewWillTransition(to:with:)``` mehod and call ```updateMenuTransition(options:)``` with desired parameters.
+Also you have possibility to update customization settings, e.g. set another options for landscape orientation. To do it you should override ```viewWillTransition(to:with:)``` mehod and call ```setMenuTransition(options:)``` with desired parameters.
 ```swift
 override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
     super.viewWillTransition(to: size, with: coordinator)
-    var options = TransitionOptions()
-    options.duration = size.width < size.height ? 0.4 : 0.6
-    options.visibleContentWidth = size.width / 5
-    updateMenuTransition(options: options)
+    var params = TransitionOptions()
+    params.duration = size.width < size.height ? 0.4 : 0.6
+    params.visibleContentWidth = size.width / 6
+    setMenuTransition(options: params)
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,19 @@ override func menuTransitionOptions() -> TransitionOptions? {
 }
 ```
 
+Also you have possibility to update customization settings, e.g. set another options for landscape orientation. To do it you should override ```viewWillTransition(to:with:)``` mehod and call ```updateMenuTransition(options:)``` with desired parameters.
+```swift
+override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+    super.viewWillTransition(to: size, with: coordinator)
+    var options = TransitionOptions()
+    options.duration = size.width < size.height ? 0.4 : 0.6
+    options.visibleContentWidth = size.width / 5
+    updateMenuTransition(options: options)
+}
+```
+
+Method ```updateMenuTransition(options:)``` could be called for setting different options for Compact and Regular sizes as well. Method ```traitCollectionDidChange(_: )``` should be used in this case.
+
  See [Sample](./Sample) for more details.
 
 # Requirements

--- a/Sample/Sample/Base.lproj/Main.storyboard
+++ b/Sample/Sample/Base.lproj/Main.storyboard
@@ -33,7 +33,7 @@
                                 </constraints>
                                 <state key="normal" image="Menu"/>
                                 <connections>
-                                    <action selector="didOpenMenu:" destination="tUv-mD-YmT" eventType="touchUpInside" id="9uI-qU-ezB"/>
+                                    <action selector="openMenu:" destination="tUv-mD-YmT" eventType="touchUpInside" id="nnJ-yv-yAN"/>
                                 </connections>
                             </button>
                         </subviews>
@@ -135,7 +135,7 @@
                                 </constraints>
                                 <state key="normal" image="Menu"/>
                                 <connections>
-                                    <action selector="didOpenMenu:" destination="MXc-SW-tl5" eventType="touchUpInside" id="Gt6-i5-Ob3"/>
+                                    <action selector="openMenu:" destination="MXc-SW-tl5" eventType="touchUpInside" id="Wyz-4e-IBT"/>
                                 </connections>
                             </button>
                         </subviews>
@@ -178,7 +178,7 @@
                                 </constraints>
                                 <state key="normal" image="Menu"/>
                                 <connections>
-                                    <action selector="didOpenMenu:" destination="iRc-1w-4bY" eventType="touchUpInside" id="GKB-Pq-W7V"/>
+                                    <action selector="openMenu:" destination="iRc-1w-4bY" eventType="touchUpInside" id="o5c-XP-Qcd"/>
                                 </connections>
                             </button>
                         </subviews>

--- a/Sample/Sample/HostViewController.swift
+++ b/Sample/Sample/HostViewController.swift
@@ -36,12 +36,17 @@ class HostViewController: MenuContainerViewController {
     }
     
     override func menuTransitionOptions() -> TransitionOptions? {
-        var options = TransitionOptions(duration: 0.4, contentScale: 0.9)
-        options.useFinishingSpringOption = false
-        options.useCancelingSpringOption = false
-        return options
+        return TransitionOptions(duration: 0.4, contentScale: 0.9)
     }
-    
+
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+        var options = TransitionOptions()
+        options.duration = size.width < size.height ? 0.4 : 0.6
+        options.visibleContentWidth = size.width / 5
+        updateMenuTransition(options: options)
+    }
+
     private func contentControllers() -> [UIViewController] {
         let controllersIdentifiers = ["Kitty", "TabBar"]
         var contentList = [UIViewController]()

--- a/Sample/Sample/HostViewController.swift
+++ b/Sample/Sample/HostViewController.swift
@@ -35,11 +35,11 @@ class HostViewController: MenuContainerViewController {
         selectContentViewController(contentViewControllers.first!)
     }
     
-    override func menuTransitionOptionsBuilder() -> TransitionOptionsBuilder? {
-        return TransitionOptionsBuilder() { builder in
-            builder.duration = 0.6
-            builder.contentScale = 0.9
-        }
+    override func menuTransitionOptions() -> TransitionOptions? {
+        var options = TransitionOptions(duration: 0.4, contentScale: 0.9)
+        options.useFinishingSpringOption = false
+        options.useCancelingSpringOption = false
+        return options
     }
     
     private func contentControllers() -> [UIViewController] {

--- a/Sample/Sample/HostViewController.swift
+++ b/Sample/Sample/HostViewController.swift
@@ -27,24 +27,21 @@ class HostViewController: MenuContainerViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-     
-        menuViewController = self.storyboard!.instantiateViewController(withIdentifier: "NavigationMenu") as! MenuViewController
-        
-        contentViewControllers = contentControllers()
+        let screenSize: CGRect = UIScreen.main.bounds
+        let params = TransitionOptions(duration: 0.4, visibleContentWidth: screenSize.width / 6)
+        setMenuTransition(options: params)
 
+        menuViewController = self.storyboard!.instantiateViewController(withIdentifier: "NavigationMenu") as! MenuViewController
+        contentViewControllers = contentControllers()
         selectContentViewController(contentViewControllers.first!)
-    }
-    
-    override func menuTransitionOptions() -> TransitionOptions? {
-        return TransitionOptions(duration: 0.4, contentScale: 0.9)
     }
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
-        var options = TransitionOptions()
-        options.duration = size.width < size.height ? 0.4 : 0.6
-        options.visibleContentWidth = size.width / 5
-        updateMenuTransition(options: options)
+        var params = TransitionOptions()
+        params.duration = size.width < size.height ? 0.4 : 0.6
+        params.visibleContentWidth = size.width / 6
+        setMenuTransition(options: params)
     }
 
     private func contentControllers() -> [UIViewController] {

--- a/Sample/Sample/HostViewController.swift
+++ b/Sample/Sample/HostViewController.swift
@@ -28,8 +28,7 @@ class HostViewController: MenuContainerViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         let screenSize: CGRect = UIScreen.main.bounds
-        let params = TransitionOptions(duration: 0.4, visibleContentWidth: screenSize.width / 6)
-        setMenuTransition(options: params)
+        self.transitionOptions = TransitionOptions(duration: 0.4, visibleContentWidth: screenSize.width / 6)
 
         menuViewController = self.storyboard!.instantiateViewController(withIdentifier: "NavigationMenu") as! MenuViewController
         contentViewControllers = contentControllers()
@@ -38,10 +37,10 @@ class HostViewController: MenuContainerViewController {
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
-        var params = TransitionOptions()
-        params.duration = size.width < size.height ? 0.4 : 0.6
-        params.visibleContentWidth = size.width / 6
-        setMenuTransition(options: params)
+        var options = TransitionOptions()
+        options.duration = size.width < size.height ? 0.4 : 0.6
+        options.visibleContentWidth = size.width / 6
+        self.transitionOptions = options
     }
 
     private func contentControllers() -> [UIViewController] {

--- a/Sample/Sample/Info.plist
+++ b/Sample/Sample/Info.plist
@@ -31,6 +31,8 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 </dict>
 </plist>

--- a/Sample/Sample/KittyViewController.swift
+++ b/Sample/Sample/KittyViewController.swift
@@ -21,7 +21,7 @@ import InteractiveSideMenu
 
 class KittyViewController: UIViewController, SideMenuItemContent {
     
-    @IBAction func didOpenMenu(_ sender: UIButton) {
+    @IBAction func openMenu(_ sender: UIButton) {
         showSideMenu()
     }
 }

--- a/Sample/Sample/TabBarViewController.swift
+++ b/Sample/Sample/TabBarViewController.swift
@@ -25,7 +25,7 @@ class TabBarViewController: UITabBarController, SideMenuItemContent {
 
 class FirstViewController: UIViewController {
 
-    @IBAction func didOpenMenu(_ sender: UIButton) {
+    @IBAction func openMenu(_ sender: UIButton) {
         if let menuItemViewController = self.tabBarController as? SideMenuItemContent {
             menuItemViewController.showSideMenu()
         }
@@ -34,7 +34,7 @@ class FirstViewController: UIViewController {
 
 class SecondViewController: UIViewController {
 
-    @IBAction func didOpenMenu(_ sender: UIButton) {
+    @IBAction func openMenu(_ sender: UIButton) {
         if let menuItemViewController = self.tabBarController as? SideMenuItemContent {
             menuItemViewController.showSideMenu()
         }

--- a/Sources/MenuAnimator.swift
+++ b/Sources/MenuAnimator.swift
@@ -118,31 +118,32 @@ class MenuInteractiveTransition: NSObject, UIViewControllerInteractiveTransition
     var present: Bool = false
     var interactionInProgress: Bool = false
 
-    private var transitionDurationPortrait: TimeInterval!
-    private var transitionDurationLandscape: TimeInterval!
-    private var transitionDuration: TimeInterval! {
+    private let transitionDurationPortrait: TimeInterval
+    private let transitionDurationLandscape: TimeInterval
+    private var transitionDuration: TimeInterval {
         return UIDevice.current.orientation.isPortrait ? transitionDurationPortrait : transitionDurationLandscape
     }
 
-    private var visibleContentWidthPortrait: CGFloat!
-    private var visibleContentWidthLandscape: CGFloat!
-    private var visibleContentWidth: CGFloat! {
+    private let visibleContentWidthPortrait: CGFloat
+    private let visibleContentWidthLandscape: CGFloat
+    private var visibleContentWidth: CGFloat {
         return UIDevice.current.orientation.isPortrait ? visibleContentWidthPortrait : visibleContentWidthLandscape
     }
 
-    private var contentScalePortrait: CGFloat!
-    private var contentScaleLandscape: CGFloat!
-    private var scaleDiff: CGFloat! {
+    private let contentScalePortrait: CGFloat
+    private let contentScaleLandscape: CGFloat
+    private var scaleDiff: CGFloat {
         return 1 - (UIDevice.current.orientation.isPortrait ? contentScalePortrait : contentScaleLandscape)
     }
-    private var useFinishingSpringOption: Bool!
-    private var useCancellingSpringOption: Bool!
-    private var finishingSpringOption: SpringOption!
-    private var cancelingSpringOption: SpringOption!
-    private var animationOptions: UIViewAnimationOptions!
+
+    private let useFinishingSpringOption: Bool
+    private let useCancellingSpringOption: Bool
+    private let finishingSpringOption: SpringOption
+    private let cancelingSpringOption: SpringOption
+    private let animationOptions: UIViewAnimationOptions
     
-    private var presentAction: Action!
-    private var dismissAction: Action!
+    private let presentAction: Action
+    private let dismissAction: Action
     
     private var transitionShouldStarted = false
     private var transitionStarted = false
@@ -153,8 +154,7 @@ class MenuInteractiveTransition: NSObject, UIViewControllerInteractiveTransition
     private var panRecognizer: UIPanGestureRecognizer!
     
     required init(presentAction: @escaping Action, dismissAction: @escaping Action, transitionOptionsBuilder: TransitionOptionsBuilder? = nil) {
-        super.init()
-  
+
         self.presentAction = presentAction
         self.dismissAction = dismissAction
         
@@ -171,6 +171,9 @@ class MenuInteractiveTransition: NSObject, UIViewControllerInteractiveTransition
         self.finishingSpringOption = options.finishingSpringOption
         self.cancelingSpringOption = options.cancelingSpringOption
         self.animationOptions = options.animationOptions
+
+        super.init()
+
     }
     
     //MARK: - Delegate methods
@@ -235,11 +238,14 @@ class MenuInteractiveTransition: NSObject, UIViewControllerInteractiveTransition
         if present {
             containerView.insertSubview(toViewController.view, belowSubview: fromViewController.view)
 
-            self.tapRecognizer = UITapGestureRecognizer(target: toViewController as! MenuViewController,
+            if self.tapRecognizer == nil {
+
+                self.tapRecognizer = UITapGestureRecognizer(target: toViewController as! MenuViewController,
                                                         action: #selector(MenuViewController.handleTap(recognizer:)))
-            
-            self.panRecognizer = UIPanGestureRecognizer(target: self,
+
+                self.panRecognizer = UIPanGestureRecognizer(target: self,
                                                         action: #selector(MenuInteractiveTransition.handlePanDismission(recognizer:)))
+            }
 
             contentSnapshotView = createSnapshotView(from: fromViewController.view)
             containerView.addSubview(contentSnapshotView)
@@ -323,10 +329,6 @@ class MenuInteractiveTransition: NSObject, UIViewControllerInteractiveTransition
             }
         }
         
-        guard let useFinishingSpringOption = self.useFinishingSpringOption else {
-            return
-        }
-        
         if useFinishingSpringOption {
             UIView.animate(withDuration: transitionDuration - transitionDuration * Double(currentPercentComplete),
                            delay: 0,
@@ -366,10 +368,6 @@ class MenuInteractiveTransition: NSObject, UIViewControllerInteractiveTransition
                 
                 transition.transitionContext.completeTransition(false)
             }
-        }
-        
-        guard let useCancellingSpringOption = self.useCancellingSpringOption else {
-            return
         }
         
         if useCancellingSpringOption {

--- a/Sources/MenuAnimator.swift
+++ b/Sources/MenuAnimator.swift
@@ -28,14 +28,6 @@ public class TransitionOptionsBuilder {
         }
     }
 
-    public var durationLandscape: TimeInterval = 0.8 {
-        willSet(newDuration) {
-            if(newDuration < 0) {
-                fatalError("Invalid duration value (\(newDuration)). It must be non negative")
-            }
-        }
-    }
-    
     public var contentScale: CGFloat = 0.88 {
         willSet(newContentScale) {
             if(newContentScale < 0) {
@@ -44,16 +36,7 @@ public class TransitionOptionsBuilder {
         }
     }
 
-    public var contentScaleLandscape: CGFloat = 0.92 {
-        willSet(newContentScale) {
-            if(newContentScale < 0) {
-                fatalError("Invalid contentScale value (\(newContentScale)). It must be non negative")
-            }
-        }
-    }
-    
     public var visibleContentWidth: CGFloat = 56.0
-    public var visibleContentWidthLandscape: CGFloat = 80.0
     public var useFinishingSpringOption = true
     public var useCancelingSpringOption = true
     public var finishingSpringOption = SpringOption(presentSpringParams: SpringParams(dampingRatio: 0.7, velocity: 0.3),
@@ -118,24 +101,9 @@ class MenuInteractiveTransition: NSObject, UIViewControllerInteractiveTransition
     var present: Bool = false
     var interactionInProgress: Bool = false
 
-    private let transitionDurationPortrait: TimeInterval
-    private let transitionDurationLandscape: TimeInterval
-    private var transitionDuration: TimeInterval {
-        return UIDevice.current.orientation.isPortrait ? transitionDurationPortrait : transitionDurationLandscape
-    }
-
-    private let visibleContentWidthPortrait: CGFloat
-    private let visibleContentWidthLandscape: CGFloat
-    private var visibleContentWidth: CGFloat {
-        return UIDevice.current.orientation.isPortrait ? visibleContentWidthPortrait : visibleContentWidthLandscape
-    }
-
-    private let contentScalePortrait: CGFloat
-    private let contentScaleLandscape: CGFloat
-    private var scaleDiff: CGFloat {
-        return 1 - (UIDevice.current.orientation.isPortrait ? contentScalePortrait : contentScaleLandscape)
-    }
-
+    private let transitionDuration: TimeInterval
+    private let visibleContentWidth: CGFloat
+    private var scaleDiff: CGFloat
     private let useFinishingSpringOption: Bool
     private let useCancellingSpringOption: Bool
     private let finishingSpringOption: SpringOption
@@ -160,20 +128,16 @@ class MenuInteractiveTransition: NSObject, UIViewControllerInteractiveTransition
         
         let options = transitionOptionsBuilder ?? TransitionOptionsBuilder.defaultOptionsBuilder()
         
-        self.transitionDurationPortrait = options.duration
-        self.transitionDurationLandscape = options.durationLandscape
-        self.contentScalePortrait = options.contentScale
-        self.contentScaleLandscape = options.contentScaleLandscape
-        self.visibleContentWidthPortrait = options.visibleContentWidth
-        self.visibleContentWidthLandscape = options.visibleContentWidthLandscape
+        self.transitionDuration = options.duration
+        self.scaleDiff = 1 - options.contentScale
+        self.visibleContentWidth = options.visibleContentWidth
         self.useFinishingSpringOption = options.useFinishingSpringOption
         self.useCancellingSpringOption = options.useCancelingSpringOption
         self.finishingSpringOption = options.finishingSpringOption
         self.cancelingSpringOption = options.cancelingSpringOption
         self.animationOptions = options.animationOptions
-
+        
         super.init()
-
     }
     
     //MARK: - Delegate methods
@@ -240,9 +204,11 @@ class MenuInteractiveTransition: NSObject, UIViewControllerInteractiveTransition
 
             if self.tapRecognizer == nil {
 
-                self.tapRecognizer = UITapGestureRecognizer(target: toViewController as! MenuViewController,
-                                                        action: #selector(MenuViewController.handleTap(recognizer:)))
-
+                guard toViewController is MenuViewController else {
+                    preconditionFailure("Invalid 'toViewController' type. It must be MenuViewController.")
+                }
+                self.tapRecognizer = UITapGestureRecognizer(target: toViewController,
+                                                            action: #selector(MenuViewController.handleTap(recognizer:)))
                 self.panRecognizer = UIPanGestureRecognizer(target: self,
                                                         action: #selector(MenuInteractiveTransition.handlePanDismission(recognizer:)))
             }

--- a/Sources/MenuAnimator.swift
+++ b/Sources/MenuAnimator.swift
@@ -129,14 +129,14 @@ class MenuInteractiveTransition: NSObject, UIViewControllerInteractiveTransition
     var present: Bool = false
     var interactionInProgress: Bool = false
 
-    private let transitionDuration: TimeInterval
-    private let visibleContentWidth: CGFloat
+    private var transitionDuration: TimeInterval
+    private var visibleContentWidth: CGFloat
     private var scaleDiff: CGFloat
-    private let useFinishingSpringOption: Bool
-    private let useCancellingSpringOption: Bool
-    private let finishingSpringOption: SpringOption
-    private let cancelingSpringOption: SpringOption
-    private let animationOptions: UIViewAnimationOptions
+    private var useFinishingSpringOption: Bool
+    private var useCancellingSpringOption: Bool
+    private var finishingSpringOption: SpringOption
+    private var cancelingSpringOption: SpringOption
+    private var animationOptions: UIViewAnimationOptions
     
     private let presentAction: Action
     private let dismissAction: Action
@@ -166,6 +166,17 @@ class MenuInteractiveTransition: NSObject, UIViewControllerInteractiveTransition
         self.animationOptions = options.animationOptions
         
         super.init()
+    }
+
+    func updateTransition(options: TransitionOptions) {
+        self.transitionDuration = options.duration
+        self.scaleDiff = 1 - options.contentScale
+        self.visibleContentWidth = options.visibleContentWidth
+        self.useFinishingSpringOption = options.useFinishingSpringOption
+        self.useCancellingSpringOption = options.useCancelingSpringOption
+        self.finishingSpringOption = options.finishingSpringOption
+        self.cancelingSpringOption = options.cancelingSpringOption
+        self.animationOptions = options.animationOptions
     }
     
     //MARK: - Delegate methods

--- a/Sources/MenuAnimator.swift
+++ b/Sources/MenuAnimator.swift
@@ -18,7 +18,7 @@
 
 import UIKit
 
-public class TransitionOptionsBuilder {
+public struct TransitionOptions {
     
     public var duration: TimeInterval = 0.5 {
         willSet(newDuration) {
@@ -44,13 +44,41 @@ public class TransitionOptionsBuilder {
     public var cancelingSpringOption = SpringOption(presentSpringParams: SpringParams(dampingRatio: 0.7, velocity: 0.0),
                                                     dismissSpringParams: SpringParams(dampingRatio: 0.7, velocity: 0.0))
     public var animationOptions: UIViewAnimationOptions = .curveEaseInOut
-    
-    public init(building: (TransitionOptionsBuilder) -> Void) {
-        building(self)
+
+    public init() {
     }
-    
-    class func defaultOptionsBuilder() -> TransitionOptionsBuilder {
-        return TransitionOptionsBuilder(){_ in }
+
+    public init(duration: TimeInterval) {
+        self.duration = duration
+    }
+
+    public init(contentScale: CGFloat) {
+        self.contentScale = contentScale
+    }
+
+    public init(visibleContentWidth: CGFloat) {
+        self.visibleContentWidth = visibleContentWidth
+    }
+
+    public init(duration: TimeInterval, contentScale: CGFloat) {
+        self.duration = duration
+        self.contentScale = contentScale
+    }
+
+    public init(duration: TimeInterval, visibleContentWidth: CGFloat) {
+        self.duration = duration
+        self.visibleContentWidth = visibleContentWidth
+    }
+
+    public init(contentScale: CGFloat, visibleContentWidth: CGFloat) {
+        self.contentScale = contentScale
+        self.visibleContentWidth = visibleContentWidth
+    }
+
+    public init(duration: TimeInterval, contentScale: CGFloat, visibleContentWidth: CGFloat) {
+        self.duration = duration
+        self.contentScale = contentScale
+        self.visibleContentWidth = visibleContentWidth
     }
 }
 
@@ -121,12 +149,12 @@ class MenuInteractiveTransition: NSObject, UIViewControllerInteractiveTransition
     private var tapRecognizer: UITapGestureRecognizer!
     private var panRecognizer: UIPanGestureRecognizer!
     
-    required init(presentAction: @escaping Action, dismissAction: @escaping Action, transitionOptionsBuilder: TransitionOptionsBuilder? = nil) {
+    required init(presentAction: @escaping Action, dismissAction: @escaping Action, transitionOptions: TransitionOptions? = nil) {
 
         self.presentAction = presentAction
         self.dismissAction = dismissAction
         
-        let options = transitionOptionsBuilder ?? TransitionOptionsBuilder.defaultOptionsBuilder()
+        let options = transitionOptions ?? TransitionOptions()
         
         self.transitionDuration = options.duration
         self.scaleDiff = 1 - options.contentScale

--- a/Sources/MenuAnimator.swift
+++ b/Sources/MenuAnimator.swift
@@ -27,6 +27,14 @@ public class TransitionOptionsBuilder {
             }
         }
     }
+
+    public var durationLandscape: TimeInterval = 0.8 {
+        willSet(newDuration) {
+            if(newDuration < 0) {
+                fatalError("Invalid duration value (\(newDuration)). It must be non negative")
+            }
+        }
+    }
     
     public var contentScale: CGFloat = 0.88 {
         willSet(newContentScale) {
@@ -35,8 +43,17 @@ public class TransitionOptionsBuilder {
             }
         }
     }
+
+    public var contentScaleLandscape: CGFloat = 0.92 {
+        willSet(newContentScale) {
+            if(newContentScale < 0) {
+                fatalError("Invalid contentScale value (\(newContentScale)). It must be non negative")
+            }
+        }
+    }
     
     public var visibleContentWidth: CGFloat = 56.0
+    public var visibleContentWidthLandscape: CGFloat = 80.0
     public var useFinishingSpringOption = true
     public var useCancelingSpringOption = true
     public var finishingSpringOption = SpringOption(presentSpringParams: SpringParams(dampingRatio: 0.7, velocity: 0.3),
@@ -100,10 +117,24 @@ class MenuInteractiveTransition: NSObject, UIViewControllerInteractiveTransition
     //
     var present: Bool = false
     var interactionInProgress: Bool = false
-    
-    private var transitionDuration: TimeInterval!
-    private var scaleDiff: CGFloat!
-    private var visibleContentWidth: CGFloat!
+
+    private var transitionDurationPortrait: TimeInterval!
+    private var transitionDurationLandscape: TimeInterval!
+    private var transitionDuration: TimeInterval! {
+        return UIDevice.current.orientation.isPortrait ? transitionDurationPortrait : transitionDurationLandscape
+    }
+
+    private var visibleContentWidthPortrait: CGFloat!
+    private var visibleContentWidthLandscape: CGFloat!
+    private var visibleContentWidth: CGFloat! {
+        return UIDevice.current.orientation.isPortrait ? visibleContentWidthPortrait : visibleContentWidthLandscape
+    }
+
+    private var contentScalePortrait: CGFloat!
+    private var contentScaleLandscape: CGFloat!
+    private var scaleDiff: CGFloat! {
+        return 1 - (UIDevice.current.orientation.isPortrait ? contentScalePortrait : contentScaleLandscape)
+    }
     private var useFinishingSpringOption: Bool!
     private var useCancellingSpringOption: Bool!
     private var finishingSpringOption: SpringOption!
@@ -129,9 +160,12 @@ class MenuInteractiveTransition: NSObject, UIViewControllerInteractiveTransition
         
         let options = transitionOptionsBuilder ?? TransitionOptionsBuilder.defaultOptionsBuilder()
         
-        self.transitionDuration = options.duration
-        self.scaleDiff = 1 - options.contentScale
-        self.visibleContentWidth = options.visibleContentWidth
+        self.transitionDurationPortrait = options.duration
+        self.transitionDurationLandscape = options.durationLandscape
+        self.contentScalePortrait = options.contentScale
+        self.contentScaleLandscape = options.contentScaleLandscape
+        self.visibleContentWidthPortrait = options.visibleContentWidth
+        self.visibleContentWidthLandscape = options.visibleContentWidthLandscape
         self.useFinishingSpringOption = options.useFinishingSpringOption
         self.useCancellingSpringOption = options.useCancelingSpringOption
         self.finishingSpringOption = options.finishingSpringOption

--- a/Sources/MenuAnimator.swift
+++ b/Sources/MenuAnimator.swift
@@ -37,11 +37,11 @@ public struct TransitionOptions {
     }
 
     public var visibleContentWidth: CGFloat = 56.0
-    public var useFinishingSpringOption = true
-    public var useCancelingSpringOption = true
-    public var finishingSpringOption = SpringOption(presentSpringParams: SpringParams(dampingRatio: 0.7, velocity: 0.3),
+    public var useFinishingSpringSettings = true
+    public var useCancellingSpringSettings = true
+    public var finishingSpringSettings = SpringSettings(presentSpringParams: SpringParams(dampingRatio: 0.7, velocity: 0.3),
                                                     dismissSpringParams: SpringParams(dampingRatio: 0.8, velocity: 0.3))
-    public var cancelingSpringOption = SpringOption(presentSpringParams: SpringParams(dampingRatio: 0.7, velocity: 0.0),
+    public var cancellingSpringSettings = SpringSettings(presentSpringParams: SpringParams(dampingRatio: 0.7, velocity: 0.0),
                                                     dismissSpringParams: SpringParams(dampingRatio: 0.7, velocity: 0.0))
     public var animationOptions: UIViewAnimationOptions = .curveEaseInOut
 
@@ -89,7 +89,7 @@ public struct SpringParams {
 }
 
 
-public struct SpringOption {
+public struct SpringSettings {
     let presentSpringParams: SpringParams
     let dismissSpringParams: SpringParams
 }
@@ -129,7 +129,7 @@ class MenuInteractiveTransition: NSObject, UIViewControllerInteractiveTransition
     var present: Bool = false
     var interactionInProgress: Bool = false
 
-    var params: TransitionOptions = TransitionOptions()
+    var options = TransitionOptions()
     private let presentAction: Action
     private let dismissAction: Action
     
@@ -147,10 +147,6 @@ class MenuInteractiveTransition: NSObject, UIViewControllerInteractiveTransition
         self.dismissAction = dismissAction
         super.init()
     }
-
-    func setTransition(options: TransitionOptions) {
-        self.params = options
-    }
     
     //MARK: - Delegate methods
     //
@@ -159,7 +155,7 @@ class MenuInteractiveTransition: NSObject, UIViewControllerInteractiveTransition
     }
     
     func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {
-        return params.duration
+        return options.duration
     }
     
     func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
@@ -232,10 +228,10 @@ class MenuInteractiveTransition: NSObject, UIViewControllerInteractiveTransition
         } else {
             containerView.addSubview(toViewController.view)
 
-            toViewController.view.transform = CGAffineTransform(scaleX: params.contentScale, y: params.contentScale)
+            toViewController.view.transform = CGAffineTransform(scaleX: options.contentScale, y: options.contentScale)
             addShadow(toView: toViewController.view)
 
-            let newOrigin = CGPoint(x: screenWidth - params.visibleContentWidth, y: toViewController.view.frame.origin.y)
+            let newOrigin = CGPoint(x: screenWidth - options.visibleContentWidth, y: toViewController.view.frame.origin.y)
             let rect = CGRect(origin: newOrigin, size: toViewController.view.frame.size)
 
             toViewController.view.frame = rect
@@ -249,11 +245,11 @@ class MenuInteractiveTransition: NSObject, UIViewControllerInteractiveTransition
         let containerView = transitionContext.containerView
         let screenWidth = containerView.frame.size.width
         
-        let totalWidth = screenWidth - params.visibleContentWidth
+        let totalWidth = screenWidth - options.visibleContentWidth
         
         if present {
 
-            let newScale = 1 - (1 - params.contentScale) * percentComplete
+            let newScale = 1 - (1 - options.contentScale) * percentComplete
             let newX = totalWidth * percentComplete
 
             contentSnapshotView.transform = CGAffineTransform(scaleX: newScale, y: newScale)
@@ -268,7 +264,7 @@ class MenuInteractiveTransition: NSObject, UIViewControllerInteractiveTransition
             let toViewController = transitionContext.viewController(forKey: UITransitionContextViewControllerKey.to)!
             let newX = totalWidth * (1 - percentComplete)
 
-            let newScale = params.contentScale + (1 - params.contentScale) * percentComplete
+            let newScale = options.contentScale + (1 - options.contentScale) * percentComplete
             toViewController.view.transform = CGAffineTransform(scaleX: newScale, y: newScale)
 
             let newOrigin = CGPoint(x: newX, y: toViewController.view.frame.origin.y)
@@ -307,18 +303,18 @@ class MenuInteractiveTransition: NSObject, UIViewControllerInteractiveTransition
             }
         }
         
-        if params.useFinishingSpringOption {
-            UIView.animate(withDuration: params.duration - params.duration * Double(currentPercentComplete),
+        if options.useFinishingSpringSettings {
+            UIView.animate(withDuration: options.duration - options.duration * Double(currentPercentComplete),
                            delay: 0,
-                           usingSpringWithDamping: present ? params.finishingSpringOption.presentSpringParams.dampingRatio : params.finishingSpringOption.dismissSpringParams.dampingRatio,
-                           initialSpringVelocity: present ? params.finishingSpringOption.presentSpringParams.velocity : params.finishingSpringOption.dismissSpringParams.velocity,
-                           options: params.animationOptions,
+                           usingSpringWithDamping: present ? options.finishingSpringSettings.presentSpringParams.dampingRatio : options.finishingSpringSettings.dismissSpringParams.dampingRatio,
+                           initialSpringVelocity: present ? options.finishingSpringSettings.presentSpringParams.velocity : options.finishingSpringSettings.dismissSpringParams.velocity,
+                           options: options.animationOptions,
                            animations: animation,
                            completion: completion)
         } else {
-            UIView.animate(withDuration: params.duration - params.duration * Double(currentPercentComplete),
+            UIView.animate(withDuration: options.duration - options.duration * Double(currentPercentComplete),
                            delay: 0,
-                           options: params.animationOptions,
+                           options: options.animationOptions,
                            animations: animation,
                            completion: completion)
         }
@@ -348,18 +344,18 @@ class MenuInteractiveTransition: NSObject, UIViewControllerInteractiveTransition
             }
         }
         
-        if params.useCancelingSpringOption {
-            UIView.animate(withDuration: params.duration - params.duration * Double(currentPercentComplete),
+        if options.useCancellingSpringSettings {
+            UIView.animate(withDuration: options.duration - options.duration * Double(currentPercentComplete),
                            delay: 0,
-                           usingSpringWithDamping: present ? params.cancelingSpringOption.presentSpringParams.dampingRatio : params.cancelingSpringOption.dismissSpringParams.dampingRatio,
-                           initialSpringVelocity: present ? params.cancelingSpringOption.presentSpringParams.velocity : params.cancelingSpringOption.dismissSpringParams.velocity,
-                           options: params.animationOptions,
+                           usingSpringWithDamping: present ? options.cancellingSpringSettings.presentSpringParams.dampingRatio : options.cancellingSpringSettings.dismissSpringParams.dampingRatio,
+                           initialSpringVelocity: present ? options.cancellingSpringSettings.presentSpringParams.velocity : options.cancellingSpringSettings.dismissSpringParams.velocity,
+                           options: options.animationOptions,
                            animations: animation,
                            completion: completion)
         } else {
-            UIView.animate(withDuration: params.duration - params.duration * Double(currentPercentComplete),
+            UIView.animate(withDuration: options.duration - options.duration * Double(currentPercentComplete),
                            delay: 0,
-                           options: params.animationOptions,
+                           options: options.animationOptions,
                            animations: animation,
                            completion: completion)
         }

--- a/Sources/MenuContainerViewController.swift
+++ b/Sources/MenuContainerViewController.swift
@@ -55,6 +55,21 @@ open class MenuContainerViewController: UIViewController {
         screenEdgePanRecognizer.edges = .left
         self.view.addGestureRecognizer(screenEdgePanRecognizer)
     }
+
+    override open func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+        print("MenuContainerViewController::viewWillTransition to: \(size)")
+        coordinator.animate(alongsideTransition: { _ in
+            self.hideSideMenu()
+        }, completion: { _ in
+            let viewBounds = CGRect(x:0, y:0, width:size.width, height:size.height)
+            let viewCenter = CGPoint(x:size.width/2, y:size.height/2)
+            self.menuViewController.view.bounds = viewBounds
+            self.menuViewController.view.center = viewCenter
+            self.view.bounds = viewBounds
+            self.view.center = viewCenter
+        })
+    }
     
     public func showSideMenu() {
         presentNavigationMenu()

--- a/Sources/MenuContainerViewController.swift
+++ b/Sources/MenuContainerViewController.swift
@@ -33,10 +33,10 @@ open class MenuContainerViewController: UIViewController {
     private weak var currentContentViewController: UIViewController?
     private var navigationMenuTransitionDelegate: MenuTransitioningDelegate!
     
-    open func menuTransitionOptionsBuilder() -> TransitionOptionsBuilder? {
+    open func menuTransitionOptions() -> TransitionOptions? {
         return nil
     }
-    
+
     override open func viewDidLoad() {
         super.viewDidLoad()
         
@@ -44,7 +44,7 @@ open class MenuContainerViewController: UIViewController {
         navigationMenuTransitionDelegate.interactiveTransition = MenuInteractiveTransition(
             presentAction: { [weak self] in self?.presentNavigationMenu() },
             dismissAction: { [weak self] in self?.dismiss(animated: true, completion: nil) },
-            transitionOptionsBuilder: menuTransitionOptionsBuilder()
+            transitionOptions: menuTransitionOptions()
         )
         
         let screenEdgePanRecognizer = UIScreenEdgePanGestureRecognizer(

--- a/Sources/MenuContainerViewController.swift
+++ b/Sources/MenuContainerViewController.swift
@@ -92,6 +92,10 @@ open class MenuContainerViewController: UIViewController {
             setCurrentView()
         }
     }
+
+    public func updateMenuTransition(options: TransitionOptions) {
+        navigationMenuTransitionDelegate.interactiveTransition.updateTransition(options: options)
+    }
     
     private func setCurrentView() {
         self.addChildViewController(currentContentViewController!)

--- a/Sources/MenuContainerViewController.swift
+++ b/Sources/MenuContainerViewController.swift
@@ -19,7 +19,7 @@
 import UIKit
 
 open class MenuContainerViewController: UIViewController {
-    
+
     public var menuViewController: MenuViewController! {
         didSet {
             menuViewController.menuContainerViewController = self
@@ -27,11 +27,15 @@ open class MenuContainerViewController: UIViewController {
             menuViewController.navigationMenuTransitionDelegate = self.navigationMenuTransitionDelegate
         }
     }
-    
+    public var transitionOptions: TransitionOptions {
+        get {
+            return navigationMenuTransitionDelegate?.interactiveTransition?.options ?? TransitionOptions()
+        }
+        set {
+            navigationMenuTransitionDelegate?.interactiveTransition?.options = newValue
+        }
+    }
     public var contentViewControllers: [UIViewController]!
-    
-    private weak var currentContentViewController: UIViewController?
-    private var navigationMenuTransitionDelegate: MenuTransitioningDelegate!
 
     override open func viewDidLoad() {
         super.viewDidLoad()
@@ -88,9 +92,10 @@ open class MenuContainerViewController: UIViewController {
         }
     }
 
-    public func setMenuTransition(options: TransitionOptions) {
-        navigationMenuTransitionDelegate?.interactiveTransition?.setTransition(options: options)
-    }
+    // MARK: - Private
+    //
+    private weak var currentContentViewController: UIViewController?
+    private var navigationMenuTransitionDelegate: MenuTransitioningDelegate!
     
     private func setCurrentView() {
         self.addChildViewController(currentContentViewController!)

--- a/Sources/MenuContainerViewController.swift
+++ b/Sources/MenuContainerViewController.swift
@@ -32,10 +32,6 @@ open class MenuContainerViewController: UIViewController {
     
     private weak var currentContentViewController: UIViewController?
     private var navigationMenuTransitionDelegate: MenuTransitioningDelegate!
-    
-    open func menuTransitionOptions() -> TransitionOptions? {
-        return nil
-    }
 
     override open func viewDidLoad() {
         super.viewDidLoad()
@@ -43,8 +39,7 @@ open class MenuContainerViewController: UIViewController {
         navigationMenuTransitionDelegate = MenuTransitioningDelegate()
         navigationMenuTransitionDelegate.interactiveTransition = MenuInteractiveTransition(
             presentAction: { [weak self] in self?.presentNavigationMenu() },
-            dismissAction: { [weak self] in self?.dismiss(animated: true, completion: nil) },
-            transitionOptions: menuTransitionOptions()
+            dismissAction: { [weak self] in self?.dismiss(animated: true, completion: nil) }
         )
         
         let screenEdgePanRecognizer = UIScreenEdgePanGestureRecognizer(
@@ -93,8 +88,8 @@ open class MenuContainerViewController: UIViewController {
         }
     }
 
-    public func updateMenuTransition(options: TransitionOptions) {
-        navigationMenuTransitionDelegate.interactiveTransition.updateTransition(options: options)
+    public func setMenuTransition(options: TransitionOptions) {
+        navigationMenuTransitionDelegate?.interactiveTransition?.setTransition(options: options)
     }
     
     private func setCurrentView() {

--- a/Sources/MenuContainerViewController.swift
+++ b/Sources/MenuContainerViewController.swift
@@ -58,9 +58,10 @@ open class MenuContainerViewController: UIViewController {
 
     override open func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
+
+        let viewBounds = CGRect(x:0, y:0, width:size.width, height:size.height)
+        let viewCenter = CGPoint(x:size.width/2, y:size.height/2)
         coordinator.animate(alongsideTransition: { _ in
-            let viewBounds = CGRect(x:0, y:0, width:size.width, height:size.height)
-            let viewCenter = CGPoint(x:size.width/2, y:size.height/2)
             self.menuViewController.view.bounds = viewBounds
             self.menuViewController.view.center = viewCenter
             self.view.bounds = viewBounds

--- a/Sources/MenuContainerViewController.swift
+++ b/Sources/MenuContainerViewController.swift
@@ -58,17 +58,15 @@ open class MenuContainerViewController: UIViewController {
 
     override open func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
-        print("MenuContainerViewController::viewWillTransition to: \(size)")
         coordinator.animate(alongsideTransition: { _ in
-            self.hideSideMenu()
-        }, completion: { _ in
             let viewBounds = CGRect(x:0, y:0, width:size.width, height:size.height)
             let viewCenter = CGPoint(x:size.width/2, y:size.height/2)
             self.menuViewController.view.bounds = viewBounds
             self.menuViewController.view.center = viewCenter
             self.view.bounds = viewBounds
             self.view.center = viewCenter
-        })
+            self.hideSideMenu()
+        }, completion: nil)
     }
     
     public func showSideMenu() {
@@ -96,7 +94,6 @@ open class MenuContainerViewController: UIViewController {
     
     private func setCurrentView() {
         self.addChildViewController(currentContentViewController!)
-        self.view.addSubview(currentContentViewController!.view)
         self.view.addSubviewWithFullSizeConstraints(view: currentContentViewController!.view)
     }
     

--- a/Sources/MenuItemContentViewController.swift
+++ b/Sources/MenuItemContentViewController.swift
@@ -19,7 +19,6 @@
 import UIKit
 
 public protocol SideMenuItemContent {
-
     func showSideMenu()
 }
 


### PR DESCRIPTION
I've added three possible settings of landscape animation: durationLandscape, contentScaleLandscape, and visibleContentWidthLandscape. The similar portrait settings are duration, contentScale, and visibleContentWidth, as I suppose that users mostly will use only portrait orientation.
If you think that we should give users opportunity to customize all settings separately from portrait, I propose to use the following scheme```builder.portrait.duration = 0.6, builder.portrait.contentScale = 0.8, builder.landscape.duration = 0.9, builder.landscape.contentScale = 0.8```