### PR TITLE
Rework MenuViewController from subclass to protocol

### DIFF
--- a/Sample/Sample/Base.lproj/Main.storyboard
+++ b/Sample/Sample/Base.lproj/Main.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12120" systemVersion="16F73" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="0Vz-9K-i9E">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12121" systemVersion="16F73" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="0Vz-9K-i9E">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -54,7 +54,7 @@
         <!--Navigation Menu View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController storyboardIdentifier="NavigationMenu" id="BYZ-38-t0r" customClass="NavigationMenuViewController" customModule="Sample" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="NavigationMenu" automaticallyAdjustsScrollViewInsets="NO" id="BYZ-38-t0r" customClass="NavigationMenuViewController" customModule="Sample" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="y3c-jy-aDJ"/>
                         <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
@@ -71,7 +71,7 @@
                                         <rect key="frame" x="0.0" y="28" width="343" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="lPg-q5-HG9" id="7Mm-JH-lHF">
-                                            <rect key="frame" x="0.0" y="0.0" width="343" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="343" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </tableViewCellContentView>
                                     </tableViewCell>

--- a/Sample/Sample/HostViewController.swift
+++ b/Sample/Sample/HostViewController.swift
@@ -42,7 +42,7 @@ class HostViewController: MenuContainerViewController {
         self.transitionOptions = TransitionOptions(duration: 0.4, visibleContentWidth: screenSize.width / 6)
 
         // Instantiate menu view controller by identifier
-        self.menuViewController = self.storyboard!.instantiateViewController(withIdentifier: "NavigationMenu") as! MenuViewController
+        self.menuViewController = self.storyboard!.instantiateViewController(withIdentifier: "NavigationMenu")
 
         // Gather content items controllers
         self.contentViewControllers = contentControllers()

--- a/Sample/Sample/HostViewController.swift
+++ b/Sample/Sample/HostViewController.swift
@@ -42,8 +42,8 @@ class HostViewController: MenuContainerViewController {
         self.transitionOptions = TransitionOptions(duration: 0.4, visibleContentWidth: screenSize.width / 6)
 
         // Instantiate menu view controller by identifier
-        self.menuViewController = self.storyboard!.instantiateViewController(withIdentifier: "NavigationMenu")
-
+        self.menuViewController = UINavigationController(rootViewController: self.storyboard!.instantiateViewController(withIdentifier: "NavigationMenu"))
+        
         // Gather content items controllers
         self.contentViewControllers = contentControllers()
 

--- a/Sample/Sample/NavigationMenuViewController.swift
+++ b/Sample/Sample/NavigationMenuViewController.swift
@@ -22,7 +22,7 @@ import InteractiveSideMenu
 /*
  Menu controller is responsible for creating its content and showing/hiding menu using 'menuContainerViewController' property.
  */
-class NavigationMenuViewController: MenuViewController {
+class NavigationMenuViewController: UIViewController {
 
     let kCellReuseIdentifier = "MenuCell"
     let menuItems = ["Kitty", "TabBar cats"]

--- a/Sample/Sample/NavigationMenuViewController.swift
+++ b/Sample/Sample/NavigationMenuViewController.swift
@@ -35,6 +35,8 @@ class NavigationMenuViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        title = "Menu"
 
         // Select the initial row
         tableView.selectRow(at: IndexPath(row: 0, section: 0), animated: false, scrollPosition: UITableViewScrollPosition.none)
@@ -63,7 +65,7 @@ extension NavigationMenuViewController: UITableViewDelegate, UITableViewDataSour
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
 
-        guard let menuContainerViewController = self.menuContainerViewController else {
+        guard let menuContainerViewController = navigationController?.menuContainerViewController else {
             return
         }
 

--- a/Sources/MenuAnimator.swift
+++ b/Sources/MenuAnimator.swift
@@ -107,9 +107,6 @@ extension MenuInteractiveTransition {
 
             if tapRecognizer == nil {
 
-                guard toViewController is MenuViewController else {
-                    fatalError("Invalid toViewController type. It must be MenuViewController")
-                }
                 tapRecognizer = UITapGestureRecognizer(target: toViewController,
                                                        action: #selector(MenuViewController.handleTap(recognizer:)))
                 panRecognizer = UIPanGestureRecognizer(target: self,

--- a/Sources/MenuContainerViewController.swift
+++ b/Sources/MenuContainerViewController.swift
@@ -22,7 +22,7 @@ import UIKit
  Container for menu view controller.
  */
 open class MenuContainerViewController: UIViewController {
-
+    
     /**
      The view controller for side menu.
      */
@@ -36,7 +36,7 @@ open class MenuContainerViewController: UIViewController {
             menuViewController.navigationMenuTransitionDelegate = navigationMenuTransitionDelegate
         }
     }
-
+    
     /**
      The options defining side menu transitioning.
      Could be set at any time of controller lifecycle.
@@ -49,19 +49,19 @@ open class MenuContainerViewController: UIViewController {
             navigationMenuTransitionDelegate?.interactiveTransition.options = newValue
         }
     }
-
+    
     /**
      The list of all content view controllers corresponding to side menu items.
      */
     public var contentViewControllers = [UIViewController]()
-
+    
     /**
      Shows left side menu.
      */
     public func showSideMenu() {
         presentNavigationMenu()
     }
-
+    
     /**
      Hides left side menu.
      Controller from the right side will be visible.
@@ -69,10 +69,10 @@ open class MenuContainerViewController: UIViewController {
     public func hideSideMenu() {
         dismiss(animated: true, completion: nil)
     }
-
+    
     /**
      Embeds menu item content view controller.
-
+     
      - parameter selectedContentVC: The view controller to be embedded.
      */
     public func selectContentViewController(_ selectedContentVC: UIViewController) {
@@ -86,12 +86,12 @@ open class MenuContainerViewController: UIViewController {
             setCurrentView(selectedContentVC)
         }
     }
-
+    
     // MARK: - Controller lifecycle
     //
     override open func viewDidLoad() {
         super.viewDidLoad()
-
+        
         navigationMenuTransitionDelegate = MenuTransitioningDelegate(interactiveTransition: MenuInteractiveTransition(
             presentAction: { [unowned self] in
                 self.presentNavigationMenu()
@@ -100,19 +100,19 @@ open class MenuContainerViewController: UIViewController {
                 self.dismiss(animated: true, completion: nil)
             }
         ))
-
+        
         let screenEdgePanRecognizer = UIScreenEdgePanGestureRecognizer(
-            target: navigationMenuTransitionDelegate.interactiveTransition,
+            target: navigationMenuTransitionDelegate?.interactiveTransition,
             action: #selector(MenuInteractiveTransition.handlePanPresentation(recognizer:))
         )
-
+        
         screenEdgePanRecognizer.edges = .left
         view.addGestureRecognizer(screenEdgePanRecognizer)
     }
-
+    
     override open func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
-
+        
         let viewBounds = CGRect(x:0, y:0, width:size.width, height:size.height)
         let viewCenter = CGPoint(x:size.width/2, y:size.height/2)
         coordinator.animate(alongsideTransition: { _ in
@@ -126,15 +126,14 @@ open class MenuContainerViewController: UIViewController {
             self.hideSideMenu()
         }, completion: nil)
     }
-
+    
     // MARK: - Private
     //
     private weak var currentContentViewController: UIViewController?
-    private var navigationMenuTransitionDelegate: MenuTransitioningDelegate!
-
+    
     /**
      Adds proper content view controller as a child.
-
+     
      - parameter selectedContentVC: The view controller to be added.
      */
     private func setCurrentView(_ selectedContentVC: UIViewController) {
@@ -142,7 +141,7 @@ open class MenuContainerViewController: UIViewController {
         view.addSubviewWithFullSizeConstraints(view: selectedContentVC.view)
         currentContentViewController = selectedContentVC
     }
-
+    
     /**
      Presents left side menu.
      */
@@ -150,7 +149,9 @@ open class MenuContainerViewController: UIViewController {
         if menuViewController == nil {
             fatalError("Invalid `menuViewController` value. It should not be nil")
         }
-        present(menuViewController, animated: true, completion: nil)
+        if let vc = menuViewController as? UIViewController {
+            present(vc, animated: true, completion: nil)
+        }
     }
 }
 
@@ -158,11 +159,11 @@ extension UIView {
     func addSubviewWithFullSizeConstraints(view : UIView) {
         insertSubviewWithFullSizeConstraints(view: view, atIndex: subviews.count)
     }
-
+    
     func insertSubviewWithFullSizeConstraints(view : UIView, atIndex: Int) {
         view.translatesAutoresizingMaskIntoConstraints = false
         insertSubview(view, at: atIndex)
-
+        
         addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:|[view]|", options: NSLayoutFormatOptions(), metrics: nil, views: ["view": view]))
         addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "H:|[view]|", options: NSLayoutFormatOptions(), metrics: nil, views: ["view": view]))
     }

--- a/Sources/MenuTransitioningDelegate.swift
+++ b/Sources/MenuTransitioningDelegate.swift
@@ -21,7 +21,7 @@ import Foundation
 /**
  Delegate of menu transitioning actions.
  */
-final class MenuTransitioningDelegate: NSObject {
+public final class MenuTransitioningDelegate: NSObject {
 
     let interactiveTransition: MenuInteractiveTransition
 
@@ -32,21 +32,21 @@ final class MenuTransitioningDelegate: NSObject {
 
 extension MenuTransitioningDelegate: UIViewControllerTransitioningDelegate {
 
-    func animationController(forPresented presented: UIViewController, presenting: UIViewController, source: UIViewController) -> UIViewControllerAnimatedTransitioning? {
+    public func animationController(forPresented presented: UIViewController, presenting: UIViewController, source: UIViewController) -> UIViewControllerAnimatedTransitioning? {
         interactiveTransition.present = true
         return interactiveTransition
     }
 
-    func animationController(forDismissed dismissed: UIViewController) -> UIViewControllerAnimatedTransitioning? {
+    public func animationController(forDismissed dismissed: UIViewController) -> UIViewControllerAnimatedTransitioning? {
         interactiveTransition.present = false
         return interactiveTransition
     }
 
-    func interactionControllerForPresentation(using animator: UIViewControllerAnimatedTransitioning) -> UIViewControllerInteractiveTransitioning? {
+    public func interactionControllerForPresentation(using animator: UIViewControllerAnimatedTransitioning) -> UIViewControllerInteractiveTransitioning? {
         return interactiveTransition.interactionInProgress ? interactiveTransition : nil
     }
 
-    func interactionControllerForDismissal(using animator: UIViewControllerAnimatedTransitioning) -> UIViewControllerInteractiveTransitioning? {
+    public func interactionControllerForDismissal(using animator: UIViewControllerAnimatedTransitioning) -> UIViewControllerInteractiveTransitioning? {
         return interactiveTransition.interactionInProgress ? interactiveTransition : nil
     }
 }

--- a/Sources/MenuViewController.swift
+++ b/Sources/MenuViewController.swift
@@ -18,12 +18,45 @@
 
 import UIKit
 
-open class MenuViewController: UIViewController {
+@objc public protocol MenuViewController
+{
+    // UIViewController
+    var transitioningDelegate: UIViewControllerTransitioningDelegate? { get set }
+    var view: UIView! { get }
+    
+    // MenuViewController
+    weak var menuContainerViewController: MenuContainerViewController? { get set }
+    var navigationMenuTransitionDelegate: MenuTransitioningDelegate? { get set }
+    @objc func handleTap(recognizer: UIGestureRecognizer)
+}
 
-    public weak var menuContainerViewController: MenuContainerViewController?
-    var navigationMenuTransitionDelegate: MenuTransitioningDelegate?
+private var key_menuContainerViewController = "menuContainerViewController"
+private var key_navigationMenuTransitionDelegate = "navigationMenuTransitionDelegate"
 
-    func handleTap(recognizer: UIGestureRecognizer){
+extension UIViewController: MenuViewController
+{
+    public var menuContainerViewController: MenuContainerViewController?
+    {
+        get {
+            return objc_getAssociatedObject(self, &key_menuContainerViewController) as? MenuContainerViewController
+        }
+        set {
+            objc_setAssociatedObject(self, &key_menuContainerViewController, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        }
+    }
+    
+    public var navigationMenuTransitionDelegate: MenuTransitioningDelegate?
+    {
+        get {
+            return objc_getAssociatedObject(self, &key_navigationMenuTransitionDelegate) as? MenuTransitioningDelegate
+        }
+        set {
+            objc_setAssociatedObject(self, &key_navigationMenuTransitionDelegate, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        }
+    }
+    
+    public func handleTap(recognizer: UIGestureRecognizer) {
         menuContainerViewController?.hideSideMenu()
     }
 }
+


### PR DESCRIPTION
This commit changes `MenuViewController` from being a subclass of  `UIViewController` to a `protocol`. 
The motivation: Allow `NavigationMenuViewController` be a subclass of another class, e.g.:

```
class BaseViewController: UIViewController {
   // some logic 
}

class NavigationMenuViewController: BaseViewController {
   // you can use BaseViewController's logic here
}
```

This also allows use of `UINavigationController` as menu (e.g. if you want that navigation bar)