### PR TITLE
Use UITableViewController as parent type for menu

### DIFF
--- a/Sources/MenuViewController.swift
+++ b/Sources/MenuViewController.swift
@@ -18,7 +18,7 @@
 
 import UIKit
 
-open class MenuViewController: UIViewController {
+open class MenuViewController: UITableViewController {
     
     public weak var menuContainerViewController: MenuContainerViewController?
     var navigationMenuTransitionDelegate: MenuTransitioningDelegate?


### PR DESCRIPTION
This is to fix #37 for everybody who need to subclass `UITableViewController`. I don't think this can be merged as is – it's rather here as a workaround until the real solution is implemented. Simply use my fork until then.

For Carthage users the inclusion would look like this as an example:
```
github "Dschee/InteractiveSideMenu" "master"
```