### PR TITLE
Addressing iOS 11 safeAreaInsets issue with content controllers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes of the library will be documented in this file.
 ## 2.2
 ### Added
 - Ability to globally change the drop shadow of the current content view while the menu is open (#61)
+- New sample project controller to tweak the transition settings
+- Status bar color can now be updated on a controller by controller basis
+
+### Changed
+- Changed default `contentScale` value from `0.88` to `0.86`
+- Updated sample project to better reflect the README demo gif
 
 ## 2.1 - [2017-10-23]
 ### Added

--- a/InteractiveSideMenu.xcodeproj/project.pbxproj
+++ b/InteractiveSideMenu.xcodeproj/project.pbxproj
@@ -278,7 +278,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = is.handsome.InteractiveSideMenu;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -300,7 +300,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = is.handsome.InteractiveSideMenu;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Sample/Sample.xcodeproj/project.pbxproj
+++ b/Sample/Sample.xcodeproj/project.pbxproj
@@ -22,6 +22,8 @@
 		D4C58476202DD6B0006EF43A /* Storyboardable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C58475202DD6B0006EF43A /* Storyboardable.swift */; };
 		D4C58478202DD6DF006EF43A /* TabBarViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D4C58477202DD6DF006EF43A /* TabBarViewController.storyboard */; };
 		D4C5847F202DD896006EF43A /* SampleMenuViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D4C5847E202DD896006EF43A /* SampleMenuViewController.storyboard */; };
+		D4C58482202DECB4006EF43A /* TweakViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C58481202DECB4006EF43A /* TweakViewController.swift */; };
+		D4C58484202DECBB006EF43A /* TweakViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D4C58483202DECBB006EF43A /* TweakViewController.storyboard */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -79,6 +81,8 @@
 		D4C58475202DD6B0006EF43A /* Storyboardable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Storyboardable.swift; sourceTree = "<group>"; };
 		D4C58477202DD6DF006EF43A /* TabBarViewController.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = TabBarViewController.storyboard; sourceTree = "<group>"; };
 		D4C5847E202DD896006EF43A /* SampleMenuViewController.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = SampleMenuViewController.storyboard; sourceTree = "<group>"; };
+		D4C58481202DECB4006EF43A /* TweakViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TweakViewController.swift; sourceTree = "<group>"; };
+		D4C58483202DECBB006EF43A /* TweakViewController.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = TweakViewController.storyboard; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -147,6 +151,8 @@
 				D4C58472202DD647006EF43A /* KittyViewController.storyboard */,
 				9A6755021EA8E30C00F0C71D /* TabBarViewController.swift */,
 				D4C58477202DD6DF006EF43A /* TabBarViewController.storyboard */,
+				D4C58481202DECB4006EF43A /* TweakViewController.swift */,
+				D4C58483202DECBB006EF43A /* TweakViewController.storyboard */,
 			);
 			path = "Menu Controllers";
 			sourceTree = "<group>";
@@ -257,6 +263,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D4C58484202DECBB006EF43A /* TweakViewController.storyboard in Resources */,
 				D4C5847F202DD896006EF43A /* SampleMenuViewController.storyboard in Resources */,
 				881EF0B21E3102E30035DEB4 /* LaunchScreen.storyboard in Resources */,
 				D4C58473202DD647006EF43A /* KittyViewController.storyboard in Resources */,
@@ -280,6 +287,7 @@
 				881EF0BF1E31037D0035DEB4 /* SampleMenuViewController.swift in Sources */,
 				9A6755031EA8E30C00F0C71D /* TabBarViewController.swift in Sources */,
 				881EF0A81E3102E30035DEB4 /* AppDelegate.swift in Sources */,
+				D4C58482202DECB4006EF43A /* TweakViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -415,7 +423,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = Sample/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = is.handsome.Sample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -429,7 +437,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = Sample/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = is.handsome.Sample;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Sample/Sample/Controllers/HostViewController.swift
+++ b/Sample/Sample/Controllers/HostViewController.swift
@@ -27,10 +27,6 @@ import InteractiveSideMenu
  */
 class HostViewController: MenuContainerViewController {
 
-    override var preferredStatusBarStyle: UIStatusBarStyle {
-        return .lightContent
-    }
-
     override var prefersStatusBarHidden: Bool {
         return false
     }
@@ -67,8 +63,9 @@ class HostViewController: MenuContainerViewController {
 
     private func contentControllers() -> [UIViewController] {
         let kittyController = KittyViewController.storyboardViewController()
-        let tabController = TabBarViewController.storyboardTabBarController()
+        let tabController = TabBarViewController.storyboardNavigationController()
+        let tweakController = TweakViewController.storyboardNavigationController()
 
-        return [kittyController, tabController]
+        return [kittyController, tabController, tweakController]
     }
 }

--- a/Sample/Sample/Controllers/SampleMenuViewController.swift
+++ b/Sample/Sample/Controllers/SampleMenuViewController.swift
@@ -27,6 +27,7 @@ class SampleMenuViewController: MenuViewController, Storyboardable {
     @IBOutlet fileprivate weak var tableView: UITableView!
     @IBOutlet fileprivate weak var avatarImageView: UIImageView!
     @IBOutlet fileprivate weak var avatarImageViewCenterXConstraint: NSLayoutConstraint!
+    private var gradientLayer = CAGradientLayer()
 
     private var gradientApplied: Bool = false
 
@@ -50,19 +51,22 @@ class SampleMenuViewController: MenuViewController, Storyboardable {
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
 
-        if !gradientApplied {
-            gradientApplied = true
-            avatarImageViewCenterXConstraint.constant = -(menuContainerViewController?.transitionOptions.visibleContentWidth ?? 0.0)/2
+        avatarImageViewCenterXConstraint.constant = -(menuContainerViewController?.transitionOptions.visibleContentWidth ?? 0.0)/2
 
-            let gradient = CAGradientLayer()
-            let topColor = UIColor(red: 16.0/255.0, green: 12.0/255.0, blue: 54.0/255.0, alpha: 1.0)
-            let bottomColor = UIColor(red: 57.0/255.0, green: 33.0/255.0, blue: 61.0/255.0, alpha: 1.0)
-            gradient.startPoint = CGPoint(x: 0.0, y: 0.0)
-            gradient.endPoint = CGPoint(x: 1.0, y: 1.0)
-            gradient.colors = [topColor.cgColor, bottomColor.cgColor]
-            gradient.frame = view.bounds
-            view.layer.insertSublayer(gradient, at: 0)
+        if gradientLayer.superlayer != nil {
+            gradientLayer.removeFromSuperlayer()
         }
+        let topColor = UIColor(red: 16.0/255.0, green: 12.0/255.0, blue: 54.0/255.0, alpha: 1.0)
+        let bottomColor = UIColor(red: 57.0/255.0, green: 33.0/255.0, blue: 61.0/255.0, alpha: 1.0)
+        gradientLayer.startPoint = CGPoint(x: 0.0, y: 0.0)
+        gradientLayer.endPoint = CGPoint(x: 1.0, y: 1.0)
+        gradientLayer.colors = [topColor.cgColor, bottomColor.cgColor]
+        gradientLayer.frame = view.bounds
+        view.layer.insertSublayer(gradientLayer, at: 0)
+    }
+
+    deinit{
+        print()
     }
 }
 

--- a/Sample/Sample/Menu Controllers/KittyViewController.storyboard
+++ b/Sample/Sample/Menu Controllers/KittyViewController.storyboard
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="kCe-tA-DYp">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="kCe-tA-DYp">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -13,10 +15,6 @@
         <scene sceneID="XXc-3z-hj0">
             <objects>
                 <viewController storyboardIdentifier="Kitty" title="Kitty" id="kCe-tA-DYp" customClass="KittyViewController" customModule="Sample" customModuleProvider="target" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="MnU-2i-clD"/>
-                        <viewControllerLayoutGuide type="bottom" id="7Ag-j5-qwW"/>
-                    </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="bee-0f-QMn">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -27,8 +25,8 @@
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8q9-2m-oaU">
                                 <rect key="frame" x="6" y="20" width="44" height="44"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="44" id="6pE-SZ-sng"/>
                                     <constraint firstAttribute="width" constant="44" id="ezd-p9-AZV"/>
+                                    <constraint firstAttribute="width" secondItem="8q9-2m-oaU" secondAttribute="height" multiplier="1:1" id="z7n-lH-ezv"/>
                                 </constraints>
                                 <state key="normal" image="Menu"/>
                                 <connections>
@@ -38,13 +36,15 @@
                         </subviews>
                         <constraints>
                             <constraint firstItem="7ls-Ss-Had" firstAttribute="top" secondItem="bee-0f-QMn" secondAttribute="top" id="5aB-JJ-2xL"/>
-                            <constraint firstItem="7Ag-j5-qwW" firstAttribute="top" secondItem="7ls-Ss-Had" secondAttribute="bottom" id="D8s-GM-dI1"/>
+                            <constraint firstAttribute="bottom" secondItem="7ls-Ss-Had" secondAttribute="bottom" id="D8s-GM-dI1"/>
                             <constraint firstAttribute="trailing" secondItem="7ls-Ss-Had" secondAttribute="trailing" id="INM-nv-WJb"/>
-                            <constraint firstItem="8q9-2m-oaU" firstAttribute="top" secondItem="bee-0f-QMn" secondAttribute="top" constant="20" id="JRX-iP-1mR"/>
-                            <constraint firstItem="8q9-2m-oaU" firstAttribute="leading" secondItem="bee-0f-QMn" secondAttribute="leading" constant="6" id="T0F-XP-Eic"/>
+                            <constraint firstItem="8q9-2m-oaU" firstAttribute="top" secondItem="Kc9-m1-lM2" secondAttribute="top" id="JRX-iP-1mR"/>
+                            <constraint firstItem="8q9-2m-oaU" firstAttribute="leading" secondItem="Kc9-m1-lM2" secondAttribute="leading" constant="6" id="T0F-XP-Eic"/>
                             <constraint firstItem="7ls-Ss-Had" firstAttribute="leading" secondItem="bee-0f-QMn" secondAttribute="leading" id="l1Y-yB-aKr"/>
                         </constraints>
+                        <viewLayoutGuide key="safeArea" id="Kc9-m1-lM2"/>
                     </view>
+                    <navigationItem key="navigationItem" id="fSg-K2-jW4"/>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Obq-0h-SGM" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>

--- a/Sample/Sample/Menu Controllers/KittyViewController.swift
+++ b/Sample/Sample/Menu Controllers/KittyViewController.swift
@@ -19,13 +19,16 @@
 import UIKit
 import InteractiveSideMenu
 
-/*
+/**
  KittyViewController is a controller relevant one of the side menu items. To indicate this it adopts `SideMenuItemContent` protocol.
  */
 class KittyViewController: UIViewController, SideMenuItemContent, Storyboardable {
 
-    /* Show side menu on menu button click
-     */
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        return .lightContent
+    }
+
+    // Show side menu on menu button click
     @IBAction func openMenu(_ sender: UIButton) {
         showSideMenu()
     }

--- a/Sample/Sample/Menu Controllers/TabBarViewController.storyboard
+++ b/Sample/Sample/Menu Controllers/TabBarViewController.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="I1w-YY-xcp">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="V1Y-cK-XuV">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
@@ -24,36 +24,12 @@
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="playful cat" translatesAutoresizingMaskIntoConstraints="NO" id="VMw-n4-DpE">
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                             </imageView>
-                            <view opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rKf-I4-kI1">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="67"/>
-                                <color key="backgroundColor" red="0.27659601900000003" green="0.27531419289999998" blue="0.27266927660000001" alpha="0.38595920140000001" colorSpace="custom" customColorSpace="sRGB"/>
-                                <accessibility key="accessibilityConfiguration">
-                                    <accessibilityTraits key="traits" notEnabled="YES"/>
-                                </accessibility>
-                            </view>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="CUK-L9-VKf">
-                                <rect key="frame" x="6" y="20" width="44" height="44"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="44" id="aYj-TD-sUj"/>
-                                    <constraint firstAttribute="width" constant="44" id="rsR-J4-dgs"/>
-                                </constraints>
-                                <state key="normal" image="Menu"/>
-                                <connections>
-                                    <action selector="openMenu:" destination="1Lo-kS-Y2F" eventType="touchUpInside" id="enx-s0-IuZ"/>
-                                </connections>
-                            </button>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                         <constraints>
                             <constraint firstAttribute="trailing" secondItem="VMw-n4-DpE" secondAttribute="trailing" id="4Ne-bh-sXn"/>
                             <constraint firstAttribute="bottom" secondItem="VMw-n4-DpE" secondAttribute="bottom" id="EF0-Uv-OKU"/>
-                            <constraint firstItem="rKf-I4-kI1" firstAttribute="leading" secondItem="3o0-5p-qCN" secondAttribute="leading" id="P42-Hg-6jf"/>
-                            <constraint firstItem="rKf-I4-kI1" firstAttribute="top" secondItem="3o0-5p-qCN" secondAttribute="top" id="Y7q-qI-gSM"/>
-                            <constraint firstItem="rKf-I4-kI1" firstAttribute="bottom" secondItem="CUK-L9-VKf" secondAttribute="bottom" constant="3" id="hhr-XD-8ce"/>
-                            <constraint firstAttribute="trailing" secondItem="rKf-I4-kI1" secondAttribute="trailing" id="kPw-yy-Ln6"/>
-                            <constraint firstItem="CUK-L9-VKf" firstAttribute="top" secondItem="3o0-5p-qCN" secondAttribute="top" constant="20" id="oZa-CF-5Gj"/>
                             <constraint firstItem="VMw-n4-DpE" firstAttribute="top" secondItem="3o0-5p-qCN" secondAttribute="top" id="tMg-qe-siH"/>
-                            <constraint firstItem="CUK-L9-VKf" firstAttribute="leading" secondItem="3o0-5p-qCN" secondAttribute="leading" constant="6" id="vdT-yh-6x6"/>
                             <constraint firstItem="VMw-n4-DpE" firstAttribute="leading" secondItem="3o0-5p-qCN" secondAttribute="leading" id="xVH-3s-sGw"/>
                         </constraints>
                     </view>
@@ -78,36 +54,12 @@
                             <imageView opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="serious cat" translatesAutoresizingMaskIntoConstraints="NO" id="Pec-XC-O6P">
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                             </imageView>
-                            <view contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zXo-Yp-9Sb">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="67"/>
-                                <color key="backgroundColor" red="0.27659601900000003" green="0.27531419289999998" blue="0.27266927660000001" alpha="0.55054873510000002" colorSpace="custom" customColorSpace="sRGB"/>
-                                <accessibility key="accessibilityConfiguration">
-                                    <accessibilityTraits key="traits" notEnabled="YES"/>
-                                </accessibility>
-                            </view>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="anU-GH-Dm3">
-                                <rect key="frame" x="6" y="20" width="44" height="44"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="44" id="HGq-CW-ZSY"/>
-                                    <constraint firstAttribute="width" constant="44" id="gt7-Me-AXd"/>
-                                </constraints>
-                                <state key="normal" image="Menu"/>
-                                <connections>
-                                    <action selector="openMenu:" destination="WOL-cV-hlK" eventType="touchUpInside" id="YCo-rH-FHp"/>
-                                </connections>
-                            </button>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="zXo-Yp-9Sb" firstAttribute="leading" secondItem="wQL-5H-EXM" secondAttribute="leading" id="1U0-8U-GxB"/>
-                            <constraint firstItem="anU-GH-Dm3" firstAttribute="top" secondItem="wQL-5H-EXM" secondAttribute="top" constant="20" id="2O0-MY-uQn"/>
                             <constraint firstAttribute="trailing" secondItem="Pec-XC-O6P" secondAttribute="trailing" id="LhP-fd-w8I"/>
                             <constraint firstItem="Pec-XC-O6P" firstAttribute="leading" secondItem="wQL-5H-EXM" secondAttribute="leading" id="Xi1-Aa-yya"/>
-                            <constraint firstItem="zXo-Yp-9Sb" firstAttribute="bottom" secondItem="anU-GH-Dm3" secondAttribute="bottom" constant="3" id="ZVB-Mp-FE7"/>
-                            <constraint firstItem="anU-GH-Dm3" firstAttribute="leading" secondItem="wQL-5H-EXM" secondAttribute="leading" constant="6" id="cRM-4u-NhD"/>
                             <constraint firstItem="Pec-XC-O6P" firstAttribute="top" secondItem="wQL-5H-EXM" secondAttribute="top" id="lSA-pP-drF"/>
-                            <constraint firstAttribute="trailing" secondItem="zXo-Yp-9Sb" secondAttribute="trailing" id="r0t-Om-9uC"/>
-                            <constraint firstItem="zXo-Yp-9Sb" firstAttribute="top" secondItem="wQL-5H-EXM" secondAttribute="top" id="tLk-rS-gmy"/>
                             <constraint firstAttribute="bottom" secondItem="Pec-XC-O6P" secondAttribute="bottom" id="xrh-Ju-3pF"/>
                         </constraints>
                     </view>
@@ -118,9 +70,33 @@
             <point key="canvasLocation" x="2868" y="-992.65367316341838"/>
         </scene>
         <!--Tab Bar-->
+        <scene sceneID="VJy-wc-eL7">
+            <objects>
+                <navigationController title="Tab Bar" id="V1Y-cK-XuV" sceneMemberID="viewController">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="QXW-dG-ViW">
+                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <connections>
+                        <segue destination="I1w-YY-xcp" kind="relationship" relationship="rootViewController" id="i9T-di-hDa"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Cz7-Ci-K8g" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="894" y="-555"/>
+        </scene>
+        <!--Tab Bar-->
         <scene sceneID="3u9-oW-Lqk">
             <objects>
                 <tabBarController storyboardIdentifier="TabBar" title="Tab Bar" id="I1w-YY-xcp" customClass="TabBarViewController" customModule="Sample" customModuleProvider="target" sceneMemberID="viewController">
+                    <navigationItem key="navigationItem" id="dWq-AK-ebe">
+                        <barButtonItem key="leftBarButtonItem" image="Menu" id="nqe-t7-lJt">
+                            <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <connections>
+                                <action selector="openMenu:" destination="I1w-YY-xcp" id="SBc-ti-hfV"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
                     <tabBar key="tabBar" contentMode="scaleToFill" id="0dI-7h-Rhe">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="49"/>
                         <autoresizingMask key="autoresizingMask"/>

--- a/Sample/Sample/Menu Controllers/TabBarViewController.swift
+++ b/Sample/Sample/Menu Controllers/TabBarViewController.swift
@@ -19,42 +19,27 @@
 import UIKit
 import InteractiveSideMenu
 
-/*
+/**
  TabBarViewController is a controller relevant one of the side menu items. To indicate this it adopts `SideMenuItemContent` protocol.
  */
 class TabBarViewController: UITabBarController, SideMenuItemContent, Storyboardable {
 
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        return .lightContent
+    }
+
+    @IBAction func openMenu(_ sender: UIBarButtonItem) {
+        showSideMenu()
+    }
+
 }
 
-/*
+/**
  The first controller of tab bar.
  */
-class FirstViewController: UIViewController {
+class FirstViewController: UIViewController { }
 
-    /*
-     Show menu on click if connected tab bar controller adopts proper protocol.
-     */
-    @IBAction func openMenu(_ sender: UIButton) {
-
-        if let menuItemViewController = self.tabBarController as? SideMenuItemContent {
-            menuItemViewController.showSideMenu()
-        }
-    }
-}
-
-/*
+/**
  The second controller of tab bar.
  */
-class SecondViewController: UIViewController {
-
-    /*
-     Show menu on click if connected tab bar controller adopts proper protocol.
-     */
-    @IBAction func openMenu(_ sender: UIButton) {
-
-        if let menuItemViewController = self.tabBarController as? SideMenuItemContent {
-            menuItemViewController.showSideMenu()
-        }
-    }
-
-}
+class SecondViewController: UIViewController { }

--- a/Sample/Sample/Menu Controllers/TweakViewController.storyboard
+++ b/Sample/Sample/Menu Controllers/TweakViewController.storyboard
@@ -1,0 +1,190 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="jfb-ED-UzV">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Tweak Settings-->
+        <scene sceneID="i51-c6-z6R">
+            <objects>
+                <navigationController title="Tweak Settings" id="jfb-ED-UzV" sceneMemberID="viewController">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" largeTitles="YES" id="jaC-sZ-Pc2">
+                        <rect key="frame" x="0.0" y="20" width="375" height="96"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <connections>
+                        <segue destination="O1j-iI-1tU" kind="relationship" relationship="rootViewController" id="T8j-EW-MQS"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Hdv-dD-U3O" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-646" y="228"/>
+        </scene>
+        <!--Tweak Settings-->
+        <scene sceneID="kTE-iQ-Cnj">
+            <objects>
+                <viewController title="Tweak Settings" id="O1j-iI-1tU" customClass="TweakViewController" customModule="Sample" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="aMf-No-3gU">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xZP-x5-Bib" userLabel="Animation Container">
+                                <rect key="frame" x="64" y="156" width="246" height="76"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Animation Duration" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ljh-zq-MVc">
+                                        <rect key="frame" x="0.0" y="0.0" width="246" height="21"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="0.5" minValue="0.0" maxValue="1" translatesAutoresizingMaskIntoConstraints="NO" id="MYI-N6-xji">
+                                        <rect key="frame" x="18" y="27" width="210" height="30"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="206" id="bqp-bK-ku7"/>
+                                            <constraint firstAttribute="width" secondItem="MYI-N6-xji" secondAttribute="height" multiplier="206:29" id="hUi-8E-nKH"/>
+                                        </constraints>
+                                        <connections>
+                                            <action selector="animationDurationDidChange:" destination="O1j-iI-1tU" eventType="valueChanged" id="mbk-Ef-vf1"/>
+                                        </connections>
+                                    </slider>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0.5" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nuF-oz-bcT">
+                                        <rect key="frame" x="113.5" y="60" width="19" height="16"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstItem="nuF-oz-bcT" firstAttribute="top" secondItem="MYI-N6-xji" secondAttribute="bottom" constant="4" id="0mz-3G-vMu"/>
+                                    <constraint firstItem="MYI-N6-xji" firstAttribute="leading" secondItem="xZP-x5-Bib" secondAttribute="leading" constant="20" id="0zE-3h-1yb"/>
+                                    <constraint firstItem="Ljh-zq-MVc" firstAttribute="leading" secondItem="xZP-x5-Bib" secondAttribute="leading" id="Ka7-sg-Rzc"/>
+                                    <constraint firstAttribute="bottom" secondItem="nuF-oz-bcT" secondAttribute="bottom" id="VGo-GL-Ca8"/>
+                                    <constraint firstAttribute="trailing" secondItem="MYI-N6-xji" secondAttribute="trailing" constant="20" id="YCV-wp-TFK"/>
+                                    <constraint firstAttribute="trailing" secondItem="Ljh-zq-MVc" secondAttribute="trailing" id="aQc-hI-X45"/>
+                                    <constraint firstItem="nuF-oz-bcT" firstAttribute="centerX" secondItem="xZP-x5-Bib" secondAttribute="centerX" id="gmN-ew-2bO"/>
+                                    <constraint firstItem="MYI-N6-xji" firstAttribute="top" secondItem="Ljh-zq-MVc" secondAttribute="bottom" constant="6" id="sTx-hq-jQp"/>
+                                    <constraint firstItem="Ljh-zq-MVc" firstAttribute="top" secondItem="xZP-x5-Bib" secondAttribute="top" id="w6W-Lw-Cyl"/>
+                                </constraints>
+                            </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="14M-Ay-GAi" userLabel="Scale Container">
+                                <rect key="frame" x="64" y="252" width="246" height="76"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Contect Scale" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dc6-ru-tjk">
+                                        <rect key="frame" x="0.0" y="0.0" width="246" height="21"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="0.85999999999999999" minValue="0.0" maxValue="1" translatesAutoresizingMaskIntoConstraints="NO" id="SjD-jD-nvG">
+                                        <rect key="frame" x="18" y="27" width="210" height="30"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" secondItem="SjD-jD-nvG" secondAttribute="height" multiplier="206:29" id="LPi-hc-Pv5"/>
+                                            <constraint firstAttribute="width" constant="206" id="PVy-1f-agk"/>
+                                        </constraints>
+                                        <connections>
+                                            <action selector="contentScaleDidChange:" destination="O1j-iI-1tU" eventType="valueChanged" id="bKn-cH-HbU"/>
+                                        </connections>
+                                    </slider>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0.86" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ch6-JC-zRH">
+                                        <rect key="frame" x="109.5" y="60" width="27.5" height="16"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstItem="SjD-jD-nvG" firstAttribute="leading" secondItem="14M-Ay-GAi" secondAttribute="leading" constant="20" id="7Wd-jH-3nZ"/>
+                                    <constraint firstItem="SjD-jD-nvG" firstAttribute="top" secondItem="dc6-ru-tjk" secondAttribute="bottom" constant="6" id="FGC-aD-pSR"/>
+                                    <constraint firstItem="Ch6-JC-zRH" firstAttribute="centerX" secondItem="14M-Ay-GAi" secondAttribute="centerX" id="QQf-J3-Sjh"/>
+                                    <constraint firstItem="Ch6-JC-zRH" firstAttribute="top" secondItem="SjD-jD-nvG" secondAttribute="bottom" constant="4" id="RDO-1J-ix6"/>
+                                    <constraint firstItem="dc6-ru-tjk" firstAttribute="top" secondItem="14M-Ay-GAi" secondAttribute="top" id="TB8-hF-WNB"/>
+                                    <constraint firstAttribute="bottom" secondItem="Ch6-JC-zRH" secondAttribute="bottom" id="ost-EL-SgT"/>
+                                    <constraint firstItem="dc6-ru-tjk" firstAttribute="leading" secondItem="14M-Ay-GAi" secondAttribute="leading" id="pNb-Z0-Tej"/>
+                                    <constraint firstAttribute="trailing" secondItem="dc6-ru-tjk" secondAttribute="trailing" id="yp5-Ic-TcC"/>
+                                    <constraint firstAttribute="trailing" secondItem="SjD-jD-nvG" secondAttribute="trailing" constant="20" id="zYB-gN-ne1"/>
+                                </constraints>
+                            </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="f8c-TI-8tN" userLabel="Visibility Container">
+                                <rect key="frame" x="64" y="348" width="246" height="76"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Content Visibility" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gOZ-qG-agZ">
+                                        <rect key="frame" x="0.0" y="0.0" width="246" height="21"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="56" minValue="0.0" maxValue="375" translatesAutoresizingMaskIntoConstraints="NO" id="ATm-x8-bXd">
+                                        <rect key="frame" x="18" y="27" width="210" height="30"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" secondItem="ATm-x8-bXd" secondAttribute="height" multiplier="206:29" id="g4H-5d-wXz"/>
+                                            <constraint firstAttribute="width" constant="206" id="gx9-71-jbE"/>
+                                        </constraints>
+                                        <connections>
+                                            <action selector="visibilityDidChange:" destination="O1j-iI-1tU" eventType="valueChanged" id="vOO-tC-bnz"/>
+                                        </connections>
+                                    </slider>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="56" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LmW-e8-ol0">
+                                        <rect key="frame" x="115" y="60" width="16.5" height="16"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstAttribute="trailing" secondItem="gOZ-qG-agZ" secondAttribute="trailing" id="3S5-zP-4s7"/>
+                                    <constraint firstItem="LmW-e8-ol0" firstAttribute="centerX" secondItem="f8c-TI-8tN" secondAttribute="centerX" id="5ZE-bl-Fw6"/>
+                                    <constraint firstItem="gOZ-qG-agZ" firstAttribute="leading" secondItem="f8c-TI-8tN" secondAttribute="leading" id="Ab1-ew-iTh"/>
+                                    <constraint firstItem="LmW-e8-ol0" firstAttribute="top" secondItem="ATm-x8-bXd" secondAttribute="bottom" constant="4" id="C1s-kt-esZ"/>
+                                    <constraint firstItem="ATm-x8-bXd" firstAttribute="top" secondItem="gOZ-qG-agZ" secondAttribute="bottom" constant="6" id="RZz-jY-D1k"/>
+                                    <constraint firstAttribute="bottom" secondItem="LmW-e8-ol0" secondAttribute="bottom" id="a7H-FD-BaN"/>
+                                    <constraint firstItem="gOZ-qG-agZ" firstAttribute="top" secondItem="f8c-TI-8tN" secondAttribute="top" id="fWE-q7-ySh"/>
+                                    <constraint firstAttribute="trailing" secondItem="ATm-x8-bXd" secondAttribute="trailing" constant="20" id="g2I-pf-oy2"/>
+                                    <constraint firstItem="ATm-x8-bXd" firstAttribute="leading" secondItem="f8c-TI-8tN" secondAttribute="leading" constant="20" id="u43-LH-P4w"/>
+                                </constraints>
+                            </view>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstItem="14M-Ay-GAi" firstAttribute="centerX" secondItem="m7R-d4-dsZ" secondAttribute="centerX" id="7aR-j3-cj4"/>
+                            <constraint firstItem="14M-Ay-GAi" firstAttribute="top" secondItem="xZP-x5-Bib" secondAttribute="bottom" constant="20" id="Eb4-Rx-PwJ"/>
+                            <constraint firstItem="xZP-x5-Bib" firstAttribute="top" secondItem="m7R-d4-dsZ" secondAttribute="top" constant="40" id="Hd1-gu-Inf"/>
+                            <constraint firstItem="f8c-TI-8tN" firstAttribute="centerX" secondItem="m7R-d4-dsZ" secondAttribute="centerX" id="Ktc-7k-bJv"/>
+                            <constraint firstItem="xZP-x5-Bib" firstAttribute="centerX" secondItem="m7R-d4-dsZ" secondAttribute="centerX" id="gLQ-I2-2yZ"/>
+                            <constraint firstItem="f8c-TI-8tN" firstAttribute="top" secondItem="14M-Ay-GAi" secondAttribute="bottom" constant="20" id="qur-6z-BmC"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="m7R-d4-dsZ"/>
+                    </view>
+                    <navigationItem key="navigationItem" title="Tweak Settings" id="9ma-4P-Yhs">
+                        <barButtonItem key="leftBarButtonItem" image="Menu" id="Zpf-wy-fn2">
+                            <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <connections>
+                                <action selector="openMenu:" destination="O1j-iI-1tU" id="TLa-bo-uiJ"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
+                    <connections>
+                        <outlet property="animationDurationValueLabel" destination="nuF-oz-bcT" id="wdq-zk-h9U"/>
+                        <outlet property="contentScaleValueLabel" destination="Ch6-JC-zRH" id="pLO-dO-xtr"/>
+                        <outlet property="visibilitySlider" destination="ATm-x8-bXd" id="aXx-tu-GfQ"/>
+                        <outlet property="visibilityValueLabel" destination="LmW-e8-ol0" id="50X-kl-l5C"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="wVY-Ig-hVq" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="285.60000000000002" y="226.23688155922042"/>
+        </scene>
+    </scenes>
+    <resources>
+        <image name="Menu" width="24" height="17"/>
+    </resources>
+</document>

--- a/Sample/Sample/Menu Controllers/TweakViewController.swift
+++ b/Sample/Sample/Menu Controllers/TweakViewController.swift
@@ -1,0 +1,61 @@
+//
+//  TweakViewController.swift
+//  Sample
+//
+//  Created by Eric Miller on 2/9/18.
+//  Copyright © 2018 Handsome. All rights reserved.
+//
+
+import UIKit
+import InteractiveSideMenu
+
+class TweakViewController: UIViewController, SideMenuItemContent, Storyboardable {
+
+    @IBOutlet private weak var animationDurationValueLabel: UILabel!
+    @IBOutlet private weak var contentScaleValueLabel: UILabel!
+    @IBOutlet private weak var visibilityValueLabel: UILabel!
+    @IBOutlet private weak var visibilitySlider: UISlider!
+
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        return .default
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        visibilitySlider.maximumValue = Float(UIScreen.main.bounds.width)
+        if let navController = parent as? UINavigationController,
+            let menuContainerController = navController.parent as? MenuContainerViewController {
+            visibilitySlider.value = Float(menuContainerController.transitionOptions.visibleContentWidth)
+            visibilityValueLabel.text = "\(menuContainerController.transitionOptions.visibleContentWidth)"
+        }
+    }
+
+    @IBAction func openMenu(_ sender: UIBarButtonItem) {
+        showSideMenu()
+    }
+
+    @IBAction func animationDurationDidChange(_ slider: UISlider) {
+        animationDurationValueLabel.text = "\(TimeInterval(slider.value))"
+        if let navController = parent as? UINavigationController,
+            let menuContainerController = navController.parent as? MenuContainerViewController {
+            menuContainerController.transitionOptions.duration = TimeInterval(slider.value)
+        }
+    }
+
+    @IBAction func contentScaleDidChange(_ slider: UISlider) {
+        contentScaleValueLabel.text = "\(CGFloat(slider.value))"
+        if let navController = parent as? UINavigationController,
+            let menuContainerController = navController.parent as? MenuContainerViewController {
+            menuContainerController.transitionOptions.contentScale = CGFloat(slider.value)
+        }
+    }
+
+    @IBAction func visibilityDidChange(_ slider: UISlider) {
+        visibilityValueLabel.text = "\(CGFloat(slider.value))"
+        if let navController = parent as? UINavigationController,
+            let menuContainerController = navController.parent as? MenuContainerViewController {
+            menuContainerController.transitionOptions.visibleContentWidth = CGFloat(slider.value)
+        }
+    }
+}

--- a/Sources/MenuContainerViewController.swift
+++ b/Sources/MenuContainerViewController.swift
@@ -23,6 +23,10 @@ import UIKit
  */
 open class MenuContainerViewController: UIViewController {
 
+    open override var preferredStatusBarStyle: UIStatusBarStyle {
+        return currentContentViewController?.preferredStatusBarStyle ?? .lightContent
+    }
+
     fileprivate weak var currentContentViewController: UIViewController?
     fileprivate var navigationMenuTransitionDelegate: MenuTransitioningDelegate!
 
@@ -195,18 +199,10 @@ extension UIView {
         view.translatesAutoresizingMaskIntoConstraints = false
         insertSubview(view, at: atIndex)
 
-        addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:|[view]|", options: NSLayoutFormatOptions(), metrics: nil, views: ["view": view]))
-        addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "H:|[view]|", options: NSLayoutFormatOptions(), metrics: nil, views: ["view": view]))
-
-//        let top: NSLayoutConstraint
-//        if #available(iOS 11.0, *) {
-//            top = view.topAnchor.constraint(equalTo: self.safeAreaLayoutGuide.topAnchor)
-//        } else {
-//            top = view.topAnchor.constraint(equalTo: self.topAnchor)
-//        }
-//        let leading = view.leadingAnchor.constraint(equalTo: self.leadingAnchor)
-//        let trailing = self.trailingAnchor.constraint(equalTo: view.trailingAnchor)
-//        let bottom = self.bottomAnchor.constraint(equalTo: view.bottomAnchor)
-//        NSLayoutConstraint.activate([top, leading, trailing, bottom])
+        let top = view.topAnchor.constraint(equalTo: self.topAnchor)
+        let leading = view.leadingAnchor.constraint(equalTo: self.leadingAnchor)
+        let trailing = self.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+        let bottom = self.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        NSLayoutConstraint.activate([top, leading, trailing, bottom])
     }
 }

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -97,7 +97,7 @@ public struct TransitionOptions {
     /// Regular view animation options. Default value is `curveEaseInOut`.
     public var animationOptions: UIViewAnimationOptions = .curveEaseInOut
 
-    public init(duration: TimeInterval = 0.5, contentScale: CGFloat = 0.88, visibleContentWidth: CGFloat = 56.0) {
+    public init(duration: TimeInterval = 0.5, contentScale: CGFloat = 0.86, visibleContentWidth: CGFloat = 56.0) {
         self.duration = duration
         self.contentScale = contentScale
         self.visibleContentWidth = visibleContentWidth

--- a/Sources/SideMenuItemContent.swift
+++ b/Sources/SideMenuItemContent.swift
@@ -37,6 +37,9 @@ extension SideMenuItemContent where Self: UIViewController {
     public func showSideMenu() {
         if let menuContainerViewController = parent as? MenuContainerViewController {
             menuContainerViewController.showSideMenu()
+        } else if let navController = parent as? UINavigationController,
+            let menuContainerViewController = navController.parent as? MenuContainerViewController {
+            menuContainerViewController.showSideMenu()
         }
     }
 }


### PR DESCRIPTION
On iOS 11, there is an issue that can arise where the content controller of the side menu will fail to have its `safeAreaInsets` set properly if the `transitionOptions` `contentScale` property set to a certain range of values.

Through testing, the value range appears to be between 0.87 - 0.91.  To combat this for the time being, the default value for `contentScale` has been adjusted from `0.88` to `0.86`.

---

A new side menu item has been added to the Sample project that allows users to adjust the `transitionOptions` in real-time, allowing for faster development and tweaking.